### PR TITLE
Fix org-superstar-restart docstring

### DIFF
--- a/org-superstar.el
+++ b/org-superstar.el
@@ -622,7 +622,7 @@ cleanup routines."
     (org-superstar--fontify-buffer))))
 
 (defun org-superstar-restart ()
-  "Re-enable ‘org-bullets-mode’, if the mode is enabled."
+  "Re-enable ‘org-superstar-mode’, if the mode is enabled."
   (interactive)
   (when org-superstar-mode
     (org-superstar-mode 0)


### PR DESCRIPTION
Thanks for the cool package!

Just noticed a vestigial mention of `org-bullets-mode` in the docstring for `org-superstar-restart`.