### PR TITLE
Use a (correct?) UTF-8 symbol for ◈

### DIFF
--- a/org-superstar.el
+++ b/org-superstar.el
@@ -89,7 +89,7 @@
     "◉"
     "○"
     "✸"
-    "✿") ;; "◉" "🞛" "○" "▷"
+    "✿") ;; "◉" "◈" "○" "▷"
   "List of bullets used in Org headings.
 It can contain any number of bullets, the Nth entry usually
 corresponding to the bullet used for level N.  The way this list


### PR DESCRIPTION
Hi,

It seems ◈ character originally used is not the standard one, as I see a box with `01F79B` when I pasted the code into my Emacs buffer, and it was rendered as a blank square in org headlines. It happened with both `Monaco` and `Cascadia Mono PL` fonts. I found (correct?) symbol from https://www.w3schools.com/charsets/ref_utf_geometric.asp. Please let me know if I'm mistaken.