### PR TITLE
Avoid positional args in define-minor-mode

### DIFF
--- a/org-superstar.el
+++ b/org-superstar.el
@@ -870,7 +870,8 @@ cleanup routines."
 ;;;###autoload
 (define-minor-mode org-superstar-mode
   "Use UTF8 bullets for headlines and plain lists."
-  nil nil nil
+  :lighter nil
+  :keymap nil
   :group 'org-superstar
   :require 'org
   (cond


### PR DESCRIPTION
The latest Emacs 28 warns against this when byte-compiling.