### PR TITLE
Avoid empty font-lock keyword if inlinetask first bullet is not used

### DIFF
--- a/org-superstar.el
+++ b/org-superstar.el
@@ -851,11 +851,11 @@ cleanup routines."
            ,@(when (featurep 'org-inlinetask)
                '((2 (org-superstar--prettify-other-hbullet)
                     prepend))))
-          ("^\\(?4:\\*\\)\\(?:\\*\\{2,\\}\\) "
-           ,@(when (and (featurep 'org-inlinetask)
-                        org-inlinetask-show-first-star
-                        (not org-superstar-remove-leading-stars))
-               '((4 (org-superstar--prettify-first-bullet)
+          ,@(when (and (featurep 'org-inlinetask)
+                       org-inlinetask-show-first-star
+                       (not org-superstar-remove-leading-stars))
+              '(("^\\(?4:\\*\\)\\(?:\\*\\{2,\\}\\) "
+                 (4 (org-superstar--prettify-first-bullet)
                     t)))))))
 
 (defun org-superstar--fontify-buffer ()


### PR DESCRIPTION
When the inlinetask first bullet should not be shown, the match regexp for
that keyword shouldn’t be added to font-lock-keywords.

Previously, this last keyword got converted to:
("^\\(?4:\\*\\)\\(?:\\*\\{2,\\}\\) " (0 nil))

When keywords were compiled. This appears to have done no harm except
unnecessary searches in fontification.



I haven’t yet tested this change extensively, but it appears to give the right results both with
`org-inlinetask-show-first-star` nil and non-nil.