### PR TITLE
disable org-superstar in org source code block

### DIFF
--- a/org-superstar.el
+++ b/org-superstar.el
@@ -637,12 +637,10 @@ This function may be expensive for files with very large plain
 lists; consider using ‘org-superstar-toggle-lightweight-lists’ in
 such cases to avoid slowdown."
   (or org-superstar-lightweight-lists
-      (and (save-match-data
+      (save-match-data
+        (and (not (org-in-src-block-p))
 	     (org-element-lineage (org-element-at-point)
-				  '(plain-list) t))
-           (save-match-data
-             (not (org-in-src-block-p)))
-	   t)))
+				  '(plain-list) t)))))
 
 (defun org-superstar-headline-or-inlinetask-p ()
   "Return t if the current match is a proper headline or inlinetask."

--- a/org-superstar.el
+++ b/org-superstar.el
@@ -640,6 +640,8 @@ such cases to avoid slowdown."
       (and (save-match-data
 	     (org-element-lineage (org-element-at-point)
 				  '(plain-list) t))
+           (save-match-data
+             (not (org-in-src-block-p)))
 	   t)))
 
 (defun org-superstar-headline-or-inlinetask-p ()


### PR DESCRIPTION
Hi,

I created this PR to disable org-superstar from transforming the symbol `-, +, *` in org source code block.

Currently, for the following code block, org-superstar will transform the `+` symbol into the right-arrow symbol. 

```emacs-lisp
    #+begin_src c
    + 1
    #+end_src
```

This PR will prevent this situation from happening.

Can you advise if this feature is reasonable?

Thank you!